### PR TITLE
feat: custom menu to show bhinsta settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET := iphone:clang:14.5
-INSTALL_TARGET_PROCESSES = SpringBoard
+INSTALL_TARGET_PROCESSES = Instagram
 
 include $(THEOS)/makefiles/common.mk
 

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.socuul.bhinsta
 Name: BHInsta
-Version: 0.2.2
+Version: 0.2.3
 Architecture: iphoneos-arm
 Description: A feature-rich tweak for Instagram on iOS!
 Maintainer: SoCuul

--- a/src/Features/General/BHSettingsMenuEntry.x
+++ b/src/Features/General/BHSettingsMenuEntry.x
@@ -2,18 +2,28 @@
 #import "../../Manager.h"
 #import "../../Controllers/SettingsViewController.h"
 
-// Workaround to show BHInsta settings by clicking on Instagram logo
-%hook IGMainAppHeaderView
-- (void)_logoButtonTapped {
-    NSLog(@"[BHInsta] Displaying BHInsta settings modal");
+// show alert when tapping settings icon (*should* be incompatible with rocket tweak)
+%hook IGProfileViewController
+- (void)navigationItemsControllerDidTapSideTray:(id)tray {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
+                               message:nil
+                               preferredStyle:UIAlertControllerStyleActionSheet];
+ 
+    [alert addAction:[UIAlertAction actionWithTitle:@"BHInsta Settings" style:UIAlertActionStyleDefault
+        handler:^(UIAlertAction *action) {
+            NSLog(@"[BHInsta] Displaying BHInsta settings modal");
+            UIViewController *rootController = [[UIApplication sharedApplication] delegate].window.rootViewController;
+            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:[SettingsViewController new]];
+            [rootController presentViewController:navigationController animated:YES completion:nil];
+        }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Instagram Settings" style:UIAlertActionStyleDefault
+        handler:^(UIAlertAction *action) {
+            %orig(tray);
+        }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel
+       handler:^(UIAlertAction *action) {}]];
 
-    UIViewController *rootController = [[UIApplication sharedApplication] delegate].window.rootViewController;
-    SettingsViewController *settingsViewController = [SettingsViewController new];
-    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
-    
-    [rootController presentViewController:navigationController animated:YES completion:nil];
-
-    return;
+    [self presentViewController:alert animated:YES completion:nil];
 }
 %end
 


### PR DESCRIPTION
instead of opening settings by tapping the insta logo, you can add an alert that asks whether you'd like to open the tweak's settings or insta settings. 

**one thing to note: this won't work with the rocket tweak as it does the same thing.**