### PR TITLE
fix: fix crash when showing alerts on iPad

### DIFF
--- a/src/Features/Save/MediaSave.x
+++ b/src/Features/Save/MediaSave.x
@@ -1,5 +1,6 @@
 #import "../../InstagramHeaders.h"
 #import "../../Manager.h"
+#import "../../Utils.h"
 
 // Download photos
 %hook IGFeedPhotoView
@@ -49,6 +50,7 @@
                 }]];
             }
             [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+            [BHIUtils prepareAlertPopoverIfNeeded:alert inView:self];
 
             NSLog(@"[BHInsta] Save media: Displaying alert");
 
@@ -119,6 +121,7 @@
                 }]];
             }
             [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+            [BHIUtils prepareAlertPopoverIfNeeded:alert inView:self];
 
             NSLog(@"[BHInsta] Save media: Displaying alert");
 
@@ -143,6 +146,7 @@
                 }]];
             }
             [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+            [BHIUtils prepareAlertPopoverIfNeeded:alert inView:self];
 
             NSLog(@"[BHInsta] Save media: Displaying alert");
 
@@ -207,6 +211,7 @@
         }
 
         [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+        [BHIUtils prepareAlertPopoverIfNeeded:alert inView:self];
         [self.viewController presentViewController:alert animated:YES completion:nil];
     }
 }

--- a/src/Features/Save/ProfileImageSave.x
+++ b/src/Features/Save/ProfileImageSave.x
@@ -1,5 +1,6 @@
 #import "../../InstagramHeaders.h"
 #import "../../Manager.h"
+#import "../../Utils.h"
 
 %hook IGProfilePicturePreviewViewController
 %property (nonatomic, strong) JGProgressHUD *hud;
@@ -33,6 +34,7 @@
             [self.hud showInView:topMostController().view];
         }]];
         [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+        [BHIUtils prepareAlertPopoverIfNeeded:alert inView:profilePictureView];
         
         NSLog(@"[BHInsta] Save pfp: Displaying alert");
 

--- a/src/Features/Save/StoriesSave.x
+++ b/src/Features/Save/StoriesSave.x
@@ -75,6 +75,7 @@
       }]];
     } */
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [BHIUtils prepareAlertPopoverIfNeeded:alert inView:self.mediaView];
 
     NSLog(@"[BHInsta] Save story: Displaying alert");
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -9,5 +9,6 @@
 // Functions
 + (BOOL)isNotch;
 + (BOOL)showConfirmation:(void(^)(void))okHandler;
++ (void)prepareAlertPopoverIfNeeded:(UIAlertController*)alert inView:(UIView*)view;
 
 @end

--- a/src/Utils.m
+++ b/src/Utils.m
@@ -24,5 +24,13 @@
 
     return nil;
 };
++ (void)prepareAlertPopoverIfNeeded:(UIAlertController*)alert inView:(UIView*)view {
+    if (alert.popoverPresentationController) {
+        // UIAlertController is a popover on iPad. Display it in the center of a view.
+        alert.popoverPresentationController.sourceView = view;
+        alert.popoverPresentationController.sourceRect = CGRectMake(view.bounds.size.width / 2.0, view.bounds.size.height / 2.0, 1.0, 1.0);
+        alert.popoverPresentationController.permittedArrowDirections = 0;
+    }
+};
 
 @end


### PR DESCRIPTION
The modalPresentationStyle of a UIAlertController is UIModalPresentationPopover on iPad. It requires to provide a sourceView and sourceRect, otherwise it crashes with NSGenericException.